### PR TITLE
Use correct args to get_links_for_children_pages

### DIFF
--- a/SimplePagesPlugin.php
+++ b/SimplePagesPlugin.php
@@ -290,7 +290,7 @@ class SimplePagesPlugin extends Omeka_Plugin_AbstractPlugin
      */
     public function filterPublicNavigationMain($nav)
     {
-        $navLinks = simple_pages_get_links_for_children_pages(0, 0, 'order', true);
+        $navLinks = simple_pages_get_links_for_children_pages(0, 'order', true);
         $nav = array_merge($nav, $navLinks);
         return $nav;
     }


### PR DESCRIPTION
There seems to have been an extra argument left in the call here. We have been passing 0 for $sort and $requireIsPublished as 'order'.

The function signature should match:
`simple_pages_get_links_for_children_pages($parentId = null, $sort = 'order', $requiresIsPublished = false)`